### PR TITLE
Use Ubuntu focal image for armhf only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN \
 
 # add local files
 COPY root/ /
+RUN chmod a+rx /etc
 
 # ports and volumes
 EXPOSE 4040

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -41,6 +41,7 @@ RUN \
 
 # add local files
 COPY root/ /
+RUN chmod a+rx /etc
 
 # ports and volumes
 EXPOSE 4040

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.15
+FROM ghcr.io/linuxserver/baseimage-ubuntu:arm32v7-focal
 
 # set version label
 ARG BUILD_DATE
@@ -13,31 +13,35 @@ BOOKSONIC_AIR_SETTINGS="/config" \
 LANG="C.UTF-8"
 
 RUN \
-  echo "**** install runtime packages ****" && \
-  apk add -U --no-cache \
-    curl \
-    ffmpeg \
-    flac \
-    fontconfig \
-    lame \
-    openjdk8-jre \
-    ttf-dejavu && \
-  echo "**** fix XXXsonic status page ****" && \
-  find /etc -name "accessibility.properties" -exec rm -fv '{}' + && \
-  find /usr -name "accessibility.properties" -exec rm -fv '{}' + && \
-  echo "**** install BOOKSONIC-AIR ****" && \
-  if [ -z ${BOOKSONIC_AIR_RELEASE+x} ]; then \
-    BOOKSONIC_AIR_RELEASE=$(curl -sX GET "https://api.github.com/repos/popeen/Booksonic-Air/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
-  fi && \
-  mkdir -p \
-    ${BOOKSONIC_AIR_HOME} && \
-  curl -o \
-  ${BOOKSONIC_AIR_HOME}/booksonic.war -L \
-    "https://github.com/popeen/Booksonic-Air/releases/download/${BOOKSONIC_AIR_RELEASE}/booksonic.war" && \
-  echo "**** cleanup ****" && \
-  rm -rf \
-	/tmp/*
+ echo "**** install runtime packages ****" && \
+ apt-get update && \
+ apt-get install -y \
+	--no-install-recommends \
+	ca-certificates \
+	ffmpeg \
+	flac \
+	fontconfig \
+	lame \
+	openjdk-8-jre \
+	ttf-dejavu && \
+ echo "**** fix XXXsonic status page ****" && \
+ find /etc -name "accessibility.properties" -exec rm -fv '{}' + && \
+ find /usr -name "accessibility.properties" -exec rm -fv '{}' + && \
+ echo "**** install BOOKSONIC-AIR ****" && \
+ if [ -z ${BOOKSONIC_AIR_RELEASE+x} ]; then \
+ 	BOOKSONIC_AIR_RELEASE=$(curl -sX GET "https://api.github.com/repos/popeen/Booksonic-Air/releases/latest" \
+        | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+ fi && \
+ mkdir -p \
+	${BOOKSONIC_AIR_HOME} && \
+ curl -o \
+ ${BOOKSONIC_AIR_HOME}/booksonic.war -L \
+	"https://github.com/popeen/Booksonic-Air/releases/download/${BOOKSONIC_AIR_RELEASE}/booksonic.war" && \
+ echo "**** cleanup ****" && \
+ rm -rf \
+	/tmp/* \
+	/var/lib/apt/lists/* \
+	/var/tmp/*
 
 # add local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -41,6 +41,7 @@ RUN \
 
 # add local files
 COPY root/ /
+RUN chmod a+rx /etc
 
 # ports and volumes
 EXPOSE 4040

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -46,5 +46,6 @@ app_setup_block: "Whilst this is a more up to date rebase of the original Bookso
 
 # changelog
 changelogs:
+  - { date: "06.06.22:", desc: "Use ubuntu for armhf; fix umask build issues." }
   - { date: "18.04.22:", desc: "Rebase to Alpine 3.15." }
   - { date: "15.09.20:", desc: "Initial Release." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-booksonic-air/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Use Ubuntu focal image for armhf only, as alpine's JRE package for armhf disables Hotspot JVM for some reason, and this causes major performance problems - e.g. 15 minute start-up times on an RPi 3B. Closes linuxserver#11.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Fixes #11 - without this, start-up times on an RPi 3B are ~15 minutes, which I feel is pretty much unusable!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have manually pushed this to my RPi 3B and it solves the startup speed problem. I have not tested the behaviour of the application extensively, but as a Java app it should be reasonably insulated from the host OS. Also, the existing state of the app on armhf is arguably unusable anyway, so little to lose by merging this, particularly as armhf is, I understand, now deprecated.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://git.alpinelinux.org/aports/commit/community/openjdk8?id=2ef23635a7f6cbdb54c363a3970362879e28e7f4